### PR TITLE
Implement networking layer and dark mode updates

### DIFF
--- a/Who will win/AiSports.xcodeproj/project.pbxproj
+++ b/Who will win/AiSports.xcodeproj/project.pbxproj
@@ -1,0 +1,592 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CE97263A2D556130000CB9EA /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE9726392D556130000CB9EA /* StoreKit.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CE97261C2D555D73000CB9EA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE9726032D555D71000CB9EA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE97260A2D555D71000CB9EA;
+			remoteInfo = AiSports;
+		};
+		CE9726262D555D73000CB9EA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE9726032D555D71000CB9EA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE97260A2D555D71000CB9EA;
+			remoteInfo = AiSports;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CE97260B2D555D71000CB9EA /* AiSports.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AiSports.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE97261B2D555D73000CB9EA /* AiSportsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AiSportsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE9726252D555D73000CB9EA /* AiSportsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AiSportsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE9726392D556130000CB9EA /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		CE97260D2D555D71000CB9EA /* AiSports */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AiSports;
+			sourceTree = "<group>";
+		};
+		CE97261E2D555D73000CB9EA /* AiSportsTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AiSportsTests;
+			sourceTree = "<group>";
+		};
+		CE9726282D555D73000CB9EA /* AiSportsUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AiSportsUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CE9726082D555D71000CB9EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CE97263A2D556130000CB9EA /* StoreKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726182D555D73000CB9EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726222D555D73000CB9EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CE9726022D555D71000CB9EA = {
+			isa = PBXGroup;
+			children = (
+				CE97260D2D555D71000CB9EA /* AiSports */,
+				CE97261E2D555D73000CB9EA /* AiSportsTests */,
+				CE9726282D555D73000CB9EA /* AiSportsUITests */,
+				CE9726382D556130000CB9EA /* Frameworks */,
+				CE97260C2D555D71000CB9EA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CE97260C2D555D71000CB9EA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CE97260B2D555D71000CB9EA /* AiSports.app */,
+				CE97261B2D555D73000CB9EA /* AiSportsTests.xctest */,
+				CE9726252D555D73000CB9EA /* AiSportsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CE9726382D556130000CB9EA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CE9726392D556130000CB9EA /* StoreKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CE97260A2D555D71000CB9EA /* AiSports */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE97262F2D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSports" */;
+			buildPhases = (
+				CE9726072D555D71000CB9EA /* Sources */,
+				CE9726082D555D71000CB9EA /* Frameworks */,
+				CE9726092D555D71000CB9EA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				CE97260D2D555D71000CB9EA /* AiSports */,
+			);
+			name = AiSports;
+			packageProductDependencies = (
+			);
+			productName = AiSports;
+			productReference = CE97260B2D555D71000CB9EA /* AiSports.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CE97261A2D555D73000CB9EA /* AiSportsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE9726322D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSportsTests" */;
+			buildPhases = (
+				CE9726172D555D73000CB9EA /* Sources */,
+				CE9726182D555D73000CB9EA /* Frameworks */,
+				CE9726192D555D73000CB9EA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CE97261D2D555D73000CB9EA /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CE97261E2D555D73000CB9EA /* AiSportsTests */,
+			);
+			name = AiSportsTests;
+			packageProductDependencies = (
+			);
+			productName = AiSportsTests;
+			productReference = CE97261B2D555D73000CB9EA /* AiSportsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CE9726242D555D73000CB9EA /* AiSportsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE9726352D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSportsUITests" */;
+			buildPhases = (
+				CE9726212D555D73000CB9EA /* Sources */,
+				CE9726222D555D73000CB9EA /* Frameworks */,
+				CE9726232D555D73000CB9EA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CE9726272D555D73000CB9EA /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CE9726282D555D73000CB9EA /* AiSportsUITests */,
+			);
+			name = AiSportsUITests;
+			packageProductDependencies = (
+			);
+			productName = AiSportsUITests;
+			productReference = CE9726252D555D73000CB9EA /* AiSportsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CE9726032D555D71000CB9EA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					CE97260A2D555D71000CB9EA = {
+						CreatedOnToolsVersion = 16.2;
+					};
+					CE97261A2D555D73000CB9EA = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = CE97260A2D555D71000CB9EA;
+					};
+					CE9726242D555D73000CB9EA = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = CE97260A2D555D71000CB9EA;
+					};
+				};
+			};
+			buildConfigurationList = CE9726062D555D71000CB9EA /* Build configuration list for PBXProject "AiSports" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CE9726022D555D71000CB9EA;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = CE97260C2D555D71000CB9EA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CE97260A2D555D71000CB9EA /* AiSports */,
+				CE97261A2D555D73000CB9EA /* AiSportsTests */,
+				CE9726242D555D73000CB9EA /* AiSportsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CE9726092D555D71000CB9EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726192D555D73000CB9EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726232D555D73000CB9EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CE9726072D555D71000CB9EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726172D555D73000CB9EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CE9726212D555D73000CB9EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CE97261D2D555D73000CB9EA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE97260A2D555D71000CB9EA /* AiSports */;
+			targetProxy = CE97261C2D555D73000CB9EA /* PBXContainerItemProxy */;
+		};
+		CE9726272D555D73000CB9EA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE97260A2D555D71000CB9EA /* AiSports */;
+			targetProxy = CE9726262D555D73000CB9EA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CE97262D2D555D73000CB9EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CE97262E2D555D73000CB9EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CE9726302D555D73000CB9EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_ASSET_PATHS = "\"AiSports/Preview Content\"";
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Who Wins";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		CE9726312D555D73000CB9EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_ASSET_PATHS = "\"AiSports/Preview Content\"";
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Who Wins";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		CE9726332D555D73000CB9EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AiSports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AiSports";
+			};
+			name = Debug;
+		};
+		CE9726342D555D73000CB9EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AiSports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AiSports";
+			};
+			name = Release;
+		};
+		CE9726362D555D73000CB9EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AiSports;
+			};
+			name = Debug;
+		};
+		CE9726372D555D73000CB9EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4KHB8EMU6N;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WGA.www;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AiSports;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CE9726062D555D71000CB9EA /* Build configuration list for PBXProject "AiSports" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE97262D2D555D73000CB9EA /* Debug */,
+				CE97262E2D555D73000CB9EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CE97262F2D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSports" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE9726302D555D73000CB9EA /* Debug */,
+				CE9726312D555D73000CB9EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CE9726322D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSportsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE9726332D555D73000CB9EA /* Debug */,
+				CE9726342D555D73000CB9EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CE9726352D555D73000CB9EA /* Build configuration list for PBXNativeTarget "AiSportsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE9726362D555D73000CB9EA /* Debug */,
+				CE9726372D555D73000CB9EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CE9726032D555D71000CB9EA /* Project object */;
+}

--- a/Who will win/AiSports.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Who will win/AiSports.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Who will win/AiSports/AiSportsApp.swift
+++ b/Who will win/AiSports/AiSportsApp.swift
@@ -1,0 +1,17 @@
+//
+//  AiSportsApp.swift
+//  AiSports
+//
+//  Created by Joe Marcus on 2/6/25.
+//
+
+import SwiftUI
+
+@main
+struct AiSportsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Who will win/AiSports/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Who will win/AiSports/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Who will win/AiSports/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Who will win/AiSports/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,36 @@
+{
+  "images" : [
+    {
+      "filename" : "ChatGPT Image May 13, 2025, 04_16_13 PM.png",
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Who will win/AiSports/Assets.xcassets/Contents.json
+++ b/Who will win/AiSports/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Who will win/AiSports/ContentView.swift
+++ b/Who will win/AiSports/ContentView.swift
@@ -1,0 +1,1021 @@
+import SwiftUI
+import StoreKit
+import UIKit
+
+// MARK: - ForecastTokenManager
+class ForecastTokenManager: ObservableObject {
+    @Published var remainingForecasts: Int {
+        didSet {
+            UserDefaults.standard.set(remainingForecasts, forKey: "RemainingForecasts")
+        }
+    }
+    
+    init() {
+        let saved = UserDefaults.standard.integer(forKey: "RemainingForecasts")
+        self.remainingForecasts = saved == 0 ? 2 : saved
+    }
+    
+    func addExtraForecasts(_ count: Int) {
+        remainingForecasts += count
+    }
+    
+    func useForecast() {
+        if remainingForecasts > 0 {
+            remainingForecasts -= 1
+        }
+    }
+}
+
+// MARK: - Forecast Model and History Store
+struct Forecast: Identifiable, Codable {
+    let id = UUID()
+    let team1Name: String
+    let team2Name: String
+    let team1Odds: String
+    let team2Odds: String
+    let selectedSport: Sport
+    let gameDate: Date
+    let result: String
+    let timestamp: Date = Date()
+    var actualResult: String?
+    var isCorrect: Bool?
+    var isLive: Bool
+}
+
+class ForecastHistoryStore: ObservableObject {
+    @Published var forecasts: [Forecast] = [] {
+        didSet { save() }
+    }
+    static let shared = ForecastHistoryStore()
+
+    private let fileURL: URL
+
+    init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        fileURL = docs.appendingPathComponent("forecasts.json")
+        load()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([Forecast].self, from: data) {
+            forecasts = decoded
+        }
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(forecasts) else { return }
+        try? data.write(to: fileURL)
+    }
+
+    func updateForecastResult(_ forecastID: UUID, actualResult: String, isCorrect: Bool) {
+        if let index = forecasts.firstIndex(where: { $0.id == forecastID }) {
+            forecasts[index].actualResult = actualResult
+            forecasts[index].isCorrect = isCorrect
+        }
+    }
+}
+
+// MARK: - GameViewModel and Data Models
+class GameViewModel: ObservableObject {
+    @Published var allGames: [Game] = []
+    @Published var isLoading: Bool = false
+    @Published var error: String?
+    @Published var hedgeNotifications: [String] = []
+
+    private var lastLoadTime: Date?
+    let supportedSportKeys = ["basketball_nba", "icehockey_nhl", "americanfootball_nfl", "soccer_epl", "baseball_mlb"]
+    private let network = NetworkManager.shared
+
+    func loadAllGames(forceRefresh: Bool = false) {
+        if !forceRefresh, let lastTime = lastLoadTime, Date().timeIntervalSince(lastTime) < 250 {
+            return
+        }
+        isLoading = true
+        error = nil
+
+        Task {
+            do {
+                let games = try await network.loadGames(for: supportedSportKeys)
+                await MainActor.run {
+                    self.allGames = games
+                    self.lastLoadTime = Date()
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.error = error.localizedDescription
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    func games(for sport: Sport) -> [Game] {
+        sport == .all ? allGames : allGames.filter { $0.sport_key == sport.apiEndpointKey }
+    }
+    
+    func checkGameResult(gameID: String, sportKey: String) async throws -> (String, Bool) {
+        try await network.fetchGameResult(gameID: gameID, sportKey: sportKey)
+    }
+    
+    func startHedgeNotifications() {
+        guard let url = URL(string: "wss://early-quiver-shingle.glitch.me") else { return }
+        let socket = WebSocketClient(url: url)
+        socket.delegate = self
+        socket.connect()
+        hedgeSocket = socket
+    }
+    private var hedgeSocket: WebSocketClient?
+}
+
+// MARK: - WebSocket Delegate
+extension GameViewModel: WebSocketClientDelegate {
+    func webSocketDidConnect() {}
+
+    func webSocketDidDisconnect(error: Error?) {}
+
+    func webSocketReceived(data: Data) {
+        do {
+            let notifications = try JSONDecoder().decode([HedgeNotification].self, from: data)
+            DispatchQueue.main.async {
+                self.hedgeNotifications = notifications.map { $0.text }
+            }
+        } catch {
+            print("Error decoding hedge notifications: \(error)")
+        }
+    }
+}
+
+
+// MARK: - Hedge Notification Model
+struct HedgeNotification: Decodable {
+    let type: String
+    let text: String
+}
+
+// MARK: - OddsAPI
+struct OddsAPI {
+    static let baseURL = "https://early-quiver-shingle.glitch.me/odds"
+    static let resultsBaseURL = "https://api.the-odds-api.com/v4/sports"
+    static let apiKey = "fa99804be12e416c46b6e9fa1ddfbc6b"
+}
+
+// MARK: - Data Models
+struct Game: Identifiable, Decodable {
+    let id: String
+    let sport_key: String?
+    let sport_title: String?
+    let commence_time: String?
+    let home_team: String?
+    let away_team: String?
+    let bookmakers: [Bookmaker]
+    let completed: Bool?
+    
+    var teams: [String]? {
+        if let home = home_team, let away = away_team {
+            return [home, away]
+        }
+        return nil
+    }
+    
+    var commenceTimeAsDate: Date? {
+        guard let timeString = commence_time else { return nil }
+        let formatter = ISO8601DateFormatter()
+        return formatter.date(from: timeString)
+    }
+    
+    var isLive: Bool {
+        guard let commenceTime = commenceTimeAsDate else { return false }
+        return commenceTime < Date() && !(completed ?? false)
+    }
+}
+
+struct Bookmaker: Decodable {
+    let key: String
+    let title: String
+    let markets: [Market]
+}
+
+struct Market: Decodable {
+    let key: String
+    let outcomes: [Outcome]
+}
+
+struct Outcome: Decodable {
+    let name: String
+    let price: Double
+}
+
+struct GameResult: Decodable {
+    let id: String
+    let sport_key: String
+    let home_team: String
+    let away_team: String
+    let scores: [TeamScore]?
+}
+
+struct TeamScore: Decodable {
+    let name: String
+    let score: Int?
+}
+
+// MARK: - Sport Enumeration
+enum Sport: String, CaseIterable, Hashable {
+    case all, basketball, hockey, football, soccer, baseball
+    
+    var emoji: String {
+        switch self {
+        case .all: return "🌍"
+        case .basketball: return "🏀"
+        case .hockey: return "🏒"
+        case .football: return "🏈"
+        case .soccer: return "⚽"
+        case .baseball: return "⚾"
+        }
+    }
+    
+    var apiEndpointKey: String? {
+        switch self {
+        case .all: return nil
+        case .basketball: return "basketball_nba"
+        case .hockey: return "icehockey_nhl"
+        case .football: return "americanfootball_nfl"
+        case .soccer: return "soccer_epl"
+        case .baseball: return "baseball_mlb"
+        }
+    }
+    
+    var displayName: String {
+        switch self {
+        case .all: return "All Sports"
+        case .basketball: return "NBA"
+        case .hockey: return "NHL"
+        case .football: return "NFL"
+        case .soccer: return "EPL"
+        case .baseball: return "MLB"
+        }
+    }
+}
+
+// MARK: - ContentView
+struct ContentView: View {
+    @State private var showWelcome: Bool = true
+    @StateObject private var gameViewModel = GameViewModel()
+    @StateObject private var forecastTokenManager = ForecastTokenManager()
+    
+    var body: some View {
+        MainTabView()
+            .environmentObject(ForecastHistoryStore.shared)
+            .environmentObject(IAPManager.shared)
+            .environmentObject(gameViewModel)
+            .environmentObject(forecastTokenManager)
+            
+            .fullScreenCover(isPresented: $showWelcome) {
+                WelcomeView(showWelcome: $showWelcome)
+            }
+            .onAppear {
+                gameViewModel.startHedgeNotifications()
+            }
+    }
+}
+
+// MARK: - MainTabView
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            NavigationView {
+                PredictorView()
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .tabItem { Label("Forecast", systemImage: "star.fill") }
+            NavigationView {
+                HistoryView()
+            }
+            .tabItem { Label("History", systemImage: "clock.fill") }
+            NavigationView {
+                SettingsView()
+            }
+            .tabItem { Label("Settings", systemImage: "gearshape.fill") }
+        }
+        .accentColor(.green)
+    }
+}
+
+// MARK: - WelcomeView
+struct WelcomeView: View {
+    @Binding var showWelcome: Bool
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 20) {
+                Image(systemName: "waveform.path.ecg")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 100, height: 100)
+                    .foregroundColor(.green)
+                Text(NSLocalizedString("welcome_title", comment: ""))
+                    .font(.system(size: 36, weight: .bold))
+                    .foregroundColor(Color.primary)
+                Text("Forecast game winners with real-time insights")
+                    .font(.system(size: 18))
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                Button(action: { showWelcome = false }) {
+                    Text(NSLocalizedString("get_started", comment: ""))
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.green)
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal, 40)
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - PredictorView
+struct PredictorView: View {
+    @State private var team1Name: String = ""
+    @State private var team2Name: String = ""
+    @State private var gameDate = Date()
+    @State private var selectedSport: Sport = .basketball
+    @State private var team1Odds: String = "-150"
+    @State private var team2Odds: String = "+150"
+    @State private var selectedGameID: String?
+    @State private var isGameLive: Bool = false
+    @State private var showSportSelection: Bool = false
+    @State private var showExtraForecastsView: Bool = false
+    @State private var showResultSheet: Bool = false
+    @State private var showAlert: Bool = false
+    
+    @EnvironmentObject var forecastTokenManager: ForecastTokenManager
+    @EnvironmentObject var gameViewModel: GameViewModel
+    
+    func resetSelection() {
+        team1Name = ""
+        team2Name = ""
+        team1Odds = "-150"
+        team2Odds = "+150"
+        gameDate = Date()
+        selectedGameID = nil
+        isGameLive = false
+    }
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Header
+                    VStack {
+                        Text("Game Forecaster")
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundColor(Color.primary)
+                        Text("Forecasts Left: \(forecastTokenManager.remainingForecasts)")
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                    }
+                    .padding(.top)
+                    
+                    // Hedge Notification
+                    if let latestHedge = gameViewModel.hedgeNotifications.first {
+                        Text("💡 Hedge Opportunity: \(latestHedge)")
+                            .font(.system(size: 14))
+                            .foregroundColor(.green)
+                            .padding()
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(10)
+                            .padding(.horizontal)
+                    }
+                    
+                    // Game Selection Card
+                    VStack(spacing: 12) {
+                        Text("Select a Game")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundColor(Color.primary)
+                        Button(action: {
+                            if forecastTokenManager.remainingForecasts > 0 {
+                                forecastTokenManager.useForecast()
+                                showSportSelection = true
+                            } else {
+                                showExtraForecastsView = true
+                            }
+                        }) {
+                            HStack {
+                                Image(systemName: "sportscourt")
+                                Text("Choose Game")
+                            }
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.green)
+                            .cornerRadius(10)
+                        }
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(15)
+                    .padding(.horizontal)
+                    
+                    // Selected Game Info
+                    if !team1Name.isEmpty && !team2Name.isEmpty {
+                        VStack(alignment: .leading, spacing: 10) { // Fixed: Changed Vargas to VStack
+                            Text("Selected Matchup")
+                                .font(.system(size: 18, weight: .semibold))
+                                .foregroundColor(Color.primary)
+                            HStack {
+                                Text(team1Name)
+                                    .foregroundColor(Color.primary)
+                                Spacer()
+                                Text("vs")
+                                    .foregroundColor(.gray)
+                                Spacer()
+                                Text(team2Name)
+                                    .foregroundColor(Color.primary)
+                            }
+                            .font(.system(size: 16))
+                            if let dateString = formattedDate(gameDate) {
+                                Text("Date: \(dateString)")
+                                    .font(.system(size: 14))
+                                    .foregroundColor(.gray)
+                            }
+                            if isGameLive {
+                                Text("🔴 Game is live!")
+                                    .font(.system(size: 14))
+                                    .foregroundColor(.red)
+                            }
+                        }
+                        .padding()
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(15)
+                        .padding(.horizontal)
+                    }
+                    
+                    // Forecast Button
+                    Button(action: {
+                        if team1Name.isEmpty || team2Name.isEmpty {
+                            showAlert = true
+                        } else {
+                            showResultSheet = true
+                        }
+                    }) {
+                        Text("Forecast Winner")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.green)
+                            .cornerRadius(10)
+                    }
+                    .padding(.horizontal)
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("Incomplete Selection"), message: Text("Please select a game to forecast."), dismissButton: .default(Text("OK")))
+                    }
+                }
+                .padding(.bottom, 20)
+            }
+        }
+        .navigationTitle("Forecast")
+        .sheet(isPresented: $showSportSelection) {
+            SportSelectionView(selectedSport: $selectedSport) { game, sport in
+                if let teams = game.teams, teams.count >= 2 {
+                    team1Name = teams[0]
+                    team2Name = teams[1]
+                }
+                let preferredBookmakers = ["draftkings", "fanduel", "bet365"]
+                let bookmaker = game.bookmakers.first { preferredBookmakers.contains($0.key.lowercased()) } ?? game.bookmakers.first
+                if let bookmaker = bookmaker,
+                   let market = bookmaker.markets.first(where: { $0.key == "h2h" }),
+                   let homeTeam = game.home_team,
+                   let awayTeam = game.away_team,
+                   market.outcomes.count >= 2 {
+                    let outcomes = market.outcomes
+                    let homeOutcome = outcomes.first { $0.name == homeTeam }
+                    let awayOutcome = outcomes.first { $0.name == awayTeam }
+                    team1Odds = homeOutcome != nil ? formatAmericanOdds(from: homeOutcome!.price) : "N/A"
+                    team2Odds = awayOutcome != nil ? formatAmericanOdds(from: awayOutcome!.price) : "N/A"
+                } else {
+                    team1Odds = "N/A"
+                    team2Odds = "N/A"
+                }
+                if let date = game.commenceTimeAsDate {
+                    gameDate = date
+                }
+                selectedGameID = game.id
+                isGameLive = game.isLive
+            }
+        }
+        .sheet(isPresented: $showExtraForecastsView) {
+            ExtraForecastsPurchaseView {
+                IAPManager.shared.purchaseExtraSearches { success in
+                    if success {
+                        forecastTokenManager.addExtraForecasts(5)
+                        showExtraForecastsView = false
+                    }
+                }
+            }
+        }
+        .fullScreenCover(isPresented: $showResultSheet) {
+            ForecastAnimationView(
+                team1Name: team1Name,
+                team2Name: team2Name,
+                team1Odds: team1Odds,
+                team2Odds: team2Odds,
+                selectedSport: selectedSport,
+                gameDate: gameDate,
+                gameID: selectedGameID,
+                isGameLive: isGameLive,
+                onDismiss: resetSelection
+            )
+            .environmentObject(ForecastHistoryStore.shared)
+            .environmentObject(gameViewModel)
+        }
+    }
+    
+    func formatAmericanOdds(from decimal: Double) -> String {
+        guard decimal > 1.0 else { return "N/A" }
+        let odds: Double = decimal < 2 ? -100 / (decimal - 1) : (decimal - 1) * 100
+        let formattedOdds = String(format: "%.0f", odds)
+        return odds > 0 ? "+\(formattedOdds)" : formattedOdds
+    }
+    
+    func formattedDate(_ date: Date) -> String? {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - ExtraForecastsPurchaseView
+struct ExtraForecastsPurchaseView: View {
+    var onPurchaseCompleted: () -> Void
+    @Environment(\.dismiss) var dismiss
+    @State private var purchaseInProgress = false
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 20) {
+                Image(systemName: "star.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.green)
+                Text("Unlock More Forecasts")
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundColor(Color.primary)
+                Text("Get 5 extra forecasts")
+                    .font(.system(size: 18))
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                Button(action: {
+                    if !purchaseInProgress {
+                        purchaseInProgress = true
+                        onPurchaseCompleted()
+                    }
+                }) {
+                    Text(purchaseInProgress ? "Processing..." : "Buy Now")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.green)
+                        .cornerRadius(10)
+                }
+                .disabled(purchaseInProgress)
+                Button(action: { dismiss() }) {
+                    Text("Cancel")
+                        .font(.system(size: 16))
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - SportSelectionView
+struct SportSelectionView: View {
+    @Environment(\.dismiss) var dismiss
+    @Binding var selectedSport: Sport
+    var onGameSelected: (Game, Sport) -> Void
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(Sport.allCases, id: \.self) { sport in
+                    NavigationLink(destination: GameSelectionView(selectedSport: .constant(sport), onGameSelected: { game in
+                        selectedSport = sport
+                        onGameSelected(game, sport)
+                        dismiss()
+                    })) {
+                        HStack(spacing: 12) {
+                            Text(sport.emoji)
+                                .font(.system(size: 24))
+                            Text(sport.displayName)
+                                .font(.system(size: 18, weight: .medium))
+                                .foregroundColor(Color.primary)
+                        }
+                        .padding(.vertical, 8)
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .background(Color(.systemBackground))
+            .navigationTitle("Select Sport")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.green)
+                }
+            }
+        }
+        
+    }
+}
+
+// MARK: - GameSelectionView
+struct GameSelectionView: View {
+    @Environment(\.dismiss) var dismiss
+    @Binding var selectedSport: Sport
+    @EnvironmentObject var gameViewModel: GameViewModel
+    var onGameSelected: (Game) -> Void
+    
+    var filteredGames: [Game] {
+        let currentDate = Date()
+        return gameViewModel.games(for: selectedSport).filter { game in
+            guard let commenceDate = game.commenceTimeAsDate else { return false }
+            return commenceDate > currentDate || game.isLive
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+                if gameViewModel.isLoading {
+                    ProgressView("Loading games...")
+                        .progressViewStyle(CircularProgressViewStyle(tint: .green))
+                } else if let error = gameViewModel.error {
+                    Text("Error: \(error)")
+                        .foregroundColor(.red)
+                        .font(.system(size: 16))
+                } else if filteredGames.isEmpty {
+                    Text("No upcoming or live games for \(selectedSport.displayName)")
+                        .foregroundColor(.gray)
+                        .font(.system(size: 16))
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 12) {
+                            ForEach(filteredGames) { game in
+                                GameCardView(game: game) {
+                                    onGameSelected(game)
+                                    dismiss()
+                                }
+                            }
+                        }
+                        .padding()
+                    }
+                }
+            }
+            .navigationTitle("Select Game")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.green)
+                }
+            }
+            .onAppear {
+                gameViewModel.loadAllGames(forceRefresh: gameViewModel.allGames.isEmpty)
+            }
+        }
+        
+    }
+}
+
+// MARK: - GameCardView
+struct GameCardView: View {
+    let game: Game
+    let onSelect: () -> Void
+    
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 8) {
+                if let teams = game.teams, teams.count >= 2 {
+                    HStack {
+                        Text(teams[0])
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(Color.primary)
+                        Spacer()
+                        Text("vs")
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                        Spacer()
+                        Text(teams[1])
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(Color.primary)
+                    }
+                }
+                if let date = game.commenceTimeAsDate {
+                    Text(date, style: .date)
+                        .font(.system(size: 14))
+                        .foregroundColor(.gray)
+                }
+                if game.isLive {
+                    Text("🔴 Live")
+                        .font(.system(size: 14))
+                        .foregroundColor(.red)
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(15)
+            .overlay(
+                RoundedRectangle(cornerRadius: 15)
+                    .stroke(Color.green.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+}
+
+// MARK: - ForecastAnimationView
+struct ForecastAnimationView: View {
+    let team1Name: String
+    let team2Name: String
+    let team1Odds: String
+    let team2Odds: String
+    let selectedSport: Sport
+    let gameDate: Date
+    let gameID: String?
+    let isGameLive: Bool
+    let onDismiss: () -> Void
+    
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var historyStore: ForecastHistoryStore
+    @EnvironmentObject var gameViewModel: GameViewModel
+    
+    @State private var pulseScale: CGFloat = 1.0
+    @State private var forecastResult: String = ""
+    @State private var isProcessing: Bool = true
+    @State private var forecastID: UUID?
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 20) {
+                if isProcessing {
+                    VStack(spacing: 20) {
+                        Text("Forecasting...")
+                            .font(.system(size: 24, weight: .bold))
+                            .foregroundColor(Color.primary)
+                        Circle()
+                            .fill(Color.green.opacity(0.3))
+                            .frame(width: 100, height: 100)
+                            .scaleEffect(pulseScale)
+                            .animation(
+                                Animation.easeInOut(duration: 1.0)
+                                    .repeatForever(autoreverses: true),
+                                value: pulseScale
+                            )
+                            .onAppear {
+                                pulseScale = 1.3
+                            }
+                        Text("Analyzing odds...")
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                    }
+                } else {
+                    VStack(spacing: 20) {
+                        Text("Forecast")
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundColor(Color.primary)
+                        Text(forecastResult)
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundColor(.green)
+                            .padding()
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(15)
+                        if isGameLive {
+                            Text("🔴 Game is live!")
+                                .font(.system(size: 16))
+                                .foregroundColor(.red)
+                        }
+                        Button(action: { /* Share functionality placeholder */ }) {
+                            HStack {
+                                Image(systemName: "square.and.arrow.up")
+                                Text("Share")
+                            }
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.green)
+                            .cornerRadius(10)
+                        }
+                        Button(action: {
+                            onDismiss()
+                            dismiss()
+                        }) {
+                            Text("Done")
+                                .font(.system(size: 18, weight: .semibold))
+                                .foregroundColor(.white)
+                                .padding()
+                                .frame(maxWidth: .infinity)
+                                .background(Color.gray)
+                                .cornerRadius(10)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .padding(.top, 40)
+        }
+        .onAppear { startForecast() }
+    }
+    
+    func startForecast() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            computeForecast()
+        }
+    }
+    
+    func computeForecast() {
+        let odds1 = Int(team1Odds.replacingOccurrences(of: "+", with: "")) ?? 150
+        let odds2 = Int(team2Odds.replacingOccurrences(of: "+", with: "")) ?? 150
+        
+        func impliedProbability(for odds: Int, isNegative: Bool) -> Double {
+            isNegative ? Double(-odds) / (Double(-odds) + 100) : 100 / (Double(odds) + 100)
+        }
+        
+        let p1 = team1Odds.hasPrefix("-") ? impliedProbability(for: odds1, isNegative: true) : impliedProbability(for: odds1, isNegative: false)
+        let p2 = team2Odds.hasPrefix("-") ? impliedProbability(for: odds2, isNegative: true) : impliedProbability(for: odds2, isNegative: false)
+        
+        let oddsGap = abs(Double(odds1 - odds2)) / 1000.0
+        let liveBoost = isGameLive ? 0.1 : 0.0
+        let base = p1 / (p1 + p2)
+        var probability = base + liveBoost - oddsGap
+        probability = min(max(probability, 0.05), 0.95)
+        let randomValue = Double.random(in: 0...1)
+        forecastResult = randomValue < probability ? "\(team1Name) wins!" : "\(team2Name) wins!"
+        
+        let newForecast = Forecast(
+            team1Name: team1Name,
+            team2Name: team2Name,
+            team1Odds: team1Odds,
+            team2Odds: team2Odds,
+            selectedSport: selectedSport,
+            gameDate: gameDate,
+            result: forecastResult,
+            actualResult: nil,
+            isCorrect: nil,
+            isLive: isGameLive
+        )
+        forecastID = newForecast.id
+        historyStore.forecasts.insert(newForecast, at: 0)
+        
+        if let gameID = gameID, let sportKey = selectedSport.apiEndpointKey, gameDate < Date() {
+            Task {
+                do {
+                    let (winner, isAvailable) = try await gameViewModel.checkGameResult(gameID: gameID, sportKey: sportKey)
+                    let actualResult = isAvailable ? "\(winner) wins!" : "Result not available"
+                    let isCorrect = isAvailable ? (winner + " wins!" == forecastResult) : nil
+                    historyStore.updateForecastResult(newForecast.id, actualResult: actualResult, isCorrect: isCorrect ?? false)
+                } catch {
+                    historyStore.updateForecastResult(newForecast.id, actualResult: "Result unavailable", isCorrect: false)
+                }
+            }
+        }
+        
+        withAnimation {
+            isProcessing = false
+        }
+    }
+    
+}
+
+// MARK: - HistoryView
+struct HistoryView: View {
+    @EnvironmentObject var historyStore: ForecastHistoryStore
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 12) {
+                    if historyStore.forecasts.isEmpty {
+                        Text("No forecasts yet")
+                            .font(.system(size: 18))
+                            .foregroundColor(.gray)
+                            .padding(.top, 20)
+                    } else {
+                        ForEach(historyStore.forecasts) { forecast in
+                            ForecastCardView(forecast: forecast)
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("History")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Clear") {
+                    historyStore.forecasts.removeAll()
+                }
+                .foregroundColor(.green)
+            }
+        }
+    }
+}
+
+// MARK: - ForecastCardView
+struct ForecastCardView: View {
+    let forecast: Forecast
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("\(forecast.team1Name) vs \(forecast.team2Name)")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(Color.primary)
+                Spacer()
+                if let isCorrect = forecast.isCorrect {
+                    Image(systemName: isCorrect ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundColor(isCorrect ? .green : .red)
+                }
+            }
+            Text("Forecast: \(forecast.result)")
+                .font(.system(size: 16))
+                .foregroundColor(Color.primary)
+            if let actualResult = forecast.actualResult {
+                Text("Actual: \(actualResult)")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+            }
+            Text("Game Date: \(forecast.gameDate, formatter: itemFormatter)")
+                .font(.system(size: 14))
+                .foregroundColor(.gray)
+            if forecast.isLive {
+                Text("🔴 Live")
+                    .font(.system(size: 14))
+                    .foregroundColor(.red)
+            }
+        }
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(15)
+        .overlay(
+            RoundedRectangle(cornerRadius: 15)
+                .stroke(Color.green.opacity(0.3), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - SettingsView
+struct SettingsView: View {
+    @EnvironmentObject var iapManager: IAPManager
+    
+    var body: some View {
+        ZStack {
+            Color(.systemBackground).ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("Settings")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(Color.primary)
+                Text("Support: support@winpulse.app")
+                    .font(.system(size: 16))
+                    .foregroundColor(.gray)
+                Button(action: { iapManager.restorePurchases() }) {
+                    Text("Restore Purchases")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.green)
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal)
+                Spacer()
+            }
+            .padding(.top)
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+// MARK: - Date Formatters
+private let itemFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter
+}()

--- a/Who will win/AiSports/IAPManager.swift
+++ b/Who will win/AiSports/IAPManager.swift
@@ -1,0 +1,89 @@
+import StoreKit
+import SwiftUI
+
+class IAPManager: NSObject, ObservableObject, SKProductsRequestDelegate, SKPaymentTransactionObserver {
+    
+    static let shared = IAPManager()
+    
+    @Published var strategiesPurchased: Bool = false
+    @Published var strategiesProduct: SKProduct?
+    @Published var extraSearchesProduct: SKProduct?
+    
+    // Updated product identifier for extra searches.
+    private let productIdentifiers: Set<String> = ["Tips", "search1"]
+    private var productsDict: [String: SKProduct] = [:]
+    
+    private override init() {
+        super.init()
+        SKPaymentQueue.default().add(self)
+        fetchProducts()
+    }
+    
+    func fetchProducts() {
+        let request = SKProductsRequest(productIdentifiers: productIdentifiers)
+        request.delegate = self
+        request.start()
+    }
+    
+    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        DispatchQueue.main.async {
+            for product in response.products {
+                self.productsDict[product.productIdentifier] = product
+            }
+            self.strategiesProduct = self.productsDict["Tips"]
+            self.extraSearchesProduct = self.productsDict["search1"]
+        }
+    }
+    
+    func purchaseStrategies() {
+        guard let product = strategiesProduct, SKPaymentQueue.canMakePayments() else {
+            print("Cannot make payments or strategies product not available")
+            return
+        }
+        let payment = SKPayment(product: product)
+        SKPaymentQueue.default().add(payment)
+    }
+    
+    func purchaseExtraSearches(completion: @escaping (Bool) -> Void) {
+        guard let product = extraSearchesProduct, SKPaymentQueue.canMakePayments() else {
+            print("Cannot make payments or extra searches product not available")
+            completion(false)
+            return
+        }
+        let payment = SKPayment(product: product)
+        ExtraSearchesPurchaseHandler.shared.completion = completion
+        SKPaymentQueue.default().add(payment)
+    }
+    
+    func restorePurchases() {
+        SKPaymentQueue.default().restoreCompletedTransactions()
+    }
+    
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        for transaction in transactions {
+            switch transaction.transactionState {
+            case .purchased, .restored:
+                if transaction.payment.productIdentifier == "Tips" {
+                    DispatchQueue.main.async {
+                        self.strategiesPurchased = true
+                    }
+                } else if transaction.payment.productIdentifier == "search1" {
+                    ExtraSearchesPurchaseHandler.shared.completion?(true)
+                }
+                SKPaymentQueue.default().finishTransaction(transaction)
+            case .failed:
+                if transaction.payment.productIdentifier == "search1" {
+                    ExtraSearchesPurchaseHandler.shared.completion?(false)
+                }
+                SKPaymentQueue.default().finishTransaction(transaction)
+            default:
+                break
+            }
+        }
+    }
+}
+
+class ExtraSearchesPurchaseHandler {
+    static let shared = ExtraSearchesPurchaseHandler()
+    var completion: ((Bool) -> Void)?
+}

--- a/Who will win/AiSports/Localizable.strings
+++ b/Who will win/AiSports/Localizable.strings
@@ -1,0 +1,2 @@
+"welcome_title" = "Welcome to WinPulse";
+"get_started" = "Get Started";

--- a/Who will win/AiSports/NetworkManager.swift
+++ b/Who will win/AiSports/NetworkManager.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+class NetworkManager {
+    static let shared = NetworkManager()
+    private init() {}
+
+    func loadGames(for sportKeys: [String]) async throws -> [Game] {
+        var combined: [Game] = []
+        for key in sportKeys {
+            let urlString = "\(OddsAPI.baseURL)?sport=\(key)&region=us&mkt=h2h&apiKey=\(OddsAPI.apiKey)"
+            guard let url = URL(string: urlString) else { continue }
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let games = try JSONDecoder().decode([Game].self, from: data)
+            combined.append(contentsOf: games)
+        }
+        return combined
+    }
+
+    func fetchGameResult(gameID: String, sportKey: String) async throws -> (String, Bool) {
+        let urlString = "\(OddsAPI.resultsBaseURL)/\(sportKey)/events/\(gameID)/scores?apiKey=\(OddsAPI.apiKey)"
+        guard let url = URL(string: urlString) else { throw URLError(.badURL) }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let result = try JSONDecoder().decode(GameResult.self, from: data)
+        return determineWinner(from: result)
+    }
+
+    private func determineWinner(from result: GameResult) -> (String, Bool) {
+        guard let scores = result.scores, scores.count >= 2 else {
+            return ("Result not available", false)
+        }
+        let team1Score = scores[0].score ?? 0
+        let team2Score = scores[1].score ?? 0
+        let winner = team1Score > team2Score ? scores[0].name : scores[1].name
+        return (winner, true)
+    }
+}

--- a/Who will win/AiSports/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Who will win/AiSports/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Who will win/AiSports/WebSocketClient.swift
+++ b/Who will win/AiSports/WebSocketClient.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Starscream
+
+protocol WebSocketClientDelegate: AnyObject {
+    func webSocketDidConnect()
+    func webSocketDidDisconnect(error: Error?)
+    func webSocketReceived(data: Data)
+}
+
+class WebSocketClient: NSObject, Starscream.WebSocketDelegate {
+    private var socket: Starscream.WebSocket?
+    weak var delegate: WebSocketClientDelegate?
+
+    init(url: URL) {
+        super.init()
+        var request = URLRequest(url: url)
+        socket = Starscream.WebSocket(request: request)
+        socket?.delegate = self
+    }
+
+    func connect() {
+        socket?.connect()
+    }
+
+    func disconnect() {
+        socket?.disconnect()
+    }
+
+    func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
+        switch event {
+        case .connected:
+            delegate?.webSocketDidConnect()
+        case .disconnected(_, _):
+            delegate?.webSocketDidDisconnect(error: nil)
+        case .text(let text):
+            if let data = text.data(using: .utf8) {
+                delegate?.webSocketReceived(data: data)
+            }
+        case .binary(let data):
+            delegate?.webSocketReceived(data: data)
+        default:
+            break
+        }
+    }
+}

--- a/Who will win/AiSportsTests/AiSportsTests.swift
+++ b/Who will win/AiSportsTests/AiSportsTests.swift
@@ -1,0 +1,17 @@
+//
+//  AiSportsTests.swift
+//  AiSportsTests
+//
+//  Created by Joe Marcus on 2/6/25.
+//
+
+import Testing
+@testable import AiSports
+
+struct AiSportsTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/Who will win/AiSportsUITests/AiSportsUITests.swift
+++ b/Who will win/AiSportsUITests/AiSportsUITests.swift
@@ -1,0 +1,43 @@
+//
+//  AiSportsUITests.swift
+//  AiSportsUITests
+//
+//  Created by Joe Marcus on 2/6/25.
+//
+
+import XCTest
+
+final class AiSportsUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Who will win/AiSportsUITests/AiSportsUITestsLaunchTests.swift
+++ b/Who will win/AiSportsUITests/AiSportsUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  AiSportsUITestsLaunchTests.swift
+//  AiSportsUITests
+//
+//  Created by Joe Marcus on 2/6/25.
+//
+
+import XCTest
+
+final class AiSportsUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Who will win/WinPulseTests/WinPulseTests.swift
+++ b/Who will win/WinPulseTests/WinPulseTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import AiSports
+
+final class WinPulseTests: XCTestCase {
+    func testImpliedProbability() {
+        let odds = -150
+        let negative = Double(-odds) / (Double(-odds) + 100)
+        XCTAssertEqual(round(negative * 100)/100, 0.6, accuracy: 0.01)
+    }
+
+    func testOddsFormatting() {
+        let formatted = String(format: "%d", -150)
+        XCTAssertEqual(formatted, "-150")
+    }
+}


### PR DESCRIPTION
## Summary
- add NetworkManager with async/await API calls
- persist ForecastHistoryStore using Codable
- replace deterministic forecast logic with odds-based algorithm
- localize welcome strings and support dark mode colors
- integrate Starscream-based WebSocket client
- add basic unit tests

## Testing
- `git status --short`
